### PR TITLE
Fix token expiration for datetimes

### DIFF
--- a/fastapi_paseto_auth/auth_paseto.py
+++ b/fastapi_paseto_auth/auth_paseto.py
@@ -233,11 +233,11 @@ class AuthPASETO(AuthConfig):
                 else:
                     expires_time = self._other_token_expires
             if isinstance(expires_time, timedelta):
-                expires_time = int(expires_time.seconds)
+                expires_time = int(expires_time.total_seconds())
             elif isinstance(expires_time, datetime):
                 current_time = datetime.utcnow()
                 valid_time: timedelta = expires_time - current_time
-                expires_time = int(valid_time.seconds)
+                expires_time = int(valid_time.total_seconds())
 
             return expires_time
         else:


### PR DESCRIPTION
The `seconds()` method is wrongly used because: `timedelta(days=1).seconds -> 0` (timedelta has 1 day and 0 seconds)

To count number of seconds from timedelta the `total_seconds` should be used: https://docs.python.org/3/library/datetime.html#datetime.timedelta.total_seconds.